### PR TITLE
Add basic project management and event tracking

### DIFF
--- a/src/app/api/projects/[projectId]/events/route.ts
+++ b/src/app/api/projects/[projectId]/events/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import path from 'path';
+import { appendJSONLine, readJSON, getDataDir } from '@/lib/data/storage';
+import fs from 'fs/promises';
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { projectId: string } }
+) {
+  const event = await req.json();
+  const eventsFile = path.join(getDataDir(), 'events', `${params.projectId}.jsonl`);
+  const timestamped = { ...event, timestamp: new Date().toISOString() };
+  await appendJSONLine(eventsFile, timestamped);
+  return NextResponse.json({ status: 'logged' });
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { projectId: string } }
+) {
+  const eventsFile = path.join(getDataDir(), 'events', `${params.projectId}.jsonl`);
+  try {
+    const data = await fs.readFile(eventsFile, 'utf8');
+    const events = data
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+    return NextResponse.json({ events });
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      return NextResponse.json({ events: [] });
+    }
+    throw err;
+  }
+}

--- a/src/app/api/projects/[projectId]/files/[fileName]/route.ts
+++ b/src/app/api/projects/[projectId]/files/[fileName]/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import path from 'path';
+import fs from 'fs/promises';
+import { getDataDir } from '@/lib/data/storage';
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { projectId: string; fileName: string } }
+) {
+  const filePath = path.join(getDataDir(), 'projects', params.projectId, params.fileName);
+  try {
+    const content = await fs.readFile(filePath, 'utf8');
+    return new NextResponse(content);
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      return NextResponse.json({ error: 'File not found' }, { status: 404 });
+    }
+    throw err;
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { projectId: string; fileName: string } }
+) {
+  const filePath = path.join(getDataDir(), 'projects', params.projectId, params.fileName);
+  try {
+    await fs.unlink(filePath);
+    return NextResponse.json({ status: 'deleted' });
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      return NextResponse.json({ error: 'File not found' }, { status: 404 });
+    }
+    throw err;
+  }
+}

--- a/src/app/api/projects/[projectId]/files/route.ts
+++ b/src/app/api/projects/[projectId]/files/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+import path from 'path';
+import fs from 'fs/promises';
+import { ensureDir, getDataDir } from '@/lib/data/storage';
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { projectId: string } }
+) {
+  const projectDir = path.join(getDataDir(), 'projects', params.projectId);
+  await ensureDir(projectDir);
+  const files = await fs.readdir(projectDir);
+  return NextResponse.json({ files });
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { projectId: string } }
+) {
+  const { name, content } = await req.json();
+  if (!name) {
+    return NextResponse.json({ error: 'Name required' }, { status: 400 });
+  }
+  const projectDir = path.join(getDataDir(), 'projects', params.projectId);
+  await ensureDir(projectDir);
+  await fs.writeFile(path.join(projectDir, name), content || '');
+  return NextResponse.json({ status: 'created' }, { status: 201 });
+}

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+import path from 'path';
+import { readJSON, writeJSON, ensureDir, getDataDir } from '@/lib/data/storage';
+
+interface Project {
+  id: string;
+  name: string;
+}
+
+const projectsFile = path.join(getDataDir(), 'projects.json');
+
+export async function GET() {
+  const projects = await readJSON<Project[]>(projectsFile, []);
+  return NextResponse.json({ projects });
+}
+
+export async function POST(req: NextRequest) {
+  const { name } = await req.json();
+  if (!name) {
+    return NextResponse.json({ error: 'Name required' }, { status: 400 });
+  }
+  const projects = await readJSON<Project[]>(projectsFile, []);
+  const id = name.toLowerCase().replace(/\s+/g, '-');
+  const newProject: Project = { id, name };
+  await writeJSON(projectsFile, [...projects, newProject]);
+  await ensureDir(path.join(getDataDir(), 'projects', id));
+  return NextResponse.json(newProject, { status: 201 });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,9 @@ export default function HomePage() {
   return (
     <main>
       <MainWorkspace />
+      <div className="mt-4">
+        <a href="/projects" className="text-blue-600 underline">Go to Projects</a>
+      </div>
     </main>
   );
 }

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -1,0 +1,13 @@
+import ProjectFiles from '@/components/project/project-files';
+import ProjectEvents from '@/components/project/project-events';
+
+export default function ProjectPage({ params }: { params: { projectId: string } }) {
+  const { projectId } = params;
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Project: {projectId}</h1>
+      <ProjectFiles projectId={projectId} />
+      <ProjectEvents projectId={projectId} />
+    </div>
+  );
+}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,0 +1,10 @@
+import ProjectList from '@/components/project/project-list';
+
+export default function ProjectsPage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Projects</h1>
+      <ProjectList />
+    </div>
+  );
+}

--- a/src/components/project/add-project-form.tsx
+++ b/src/components/project/add-project-form.tsx
@@ -1,0 +1,24 @@
+"use client";
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+export default function AddProjectForm({ onCreated }: { onCreated?: () => void }) {
+  const [name, setName] = useState('');
+  const create = async () => {
+    if (!name.trim()) return;
+    await fetch('/api/projects', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name })
+    });
+    setName('');
+    onCreated?.();
+  };
+  return (
+    <div className="flex gap-2">
+      <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Project name" />
+      <Button onClick={create}>Add</Button>
+    </div>
+  );
+}

--- a/src/components/project/project-events.tsx
+++ b/src/components/project/project-events.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { useEffect, useState } from 'react';
+
+interface Event {
+  type: string;
+  file?: string;
+  user: string;
+  timestamp: string;
+}
+
+export default function ProjectEvents({ projectId }: { projectId: string }) {
+  const [events, setEvents] = useState<Event[]>([]);
+
+  const load = async () => {
+    const res = await fetch(`/api/projects/${projectId}/events`);
+    const data = await res.json();
+    setEvents(data.events);
+  };
+
+  useEffect(() => { load(); }, [projectId]);
+
+  return (
+    <div>
+      <h3 className="font-semibold">Events</h3>
+      <ul className="list-disc pl-4">
+        {events.map((e, idx) => (
+          <li key={idx}>{e.timestamp} - {e.type} {e.file ? `(${e.file})` : ''} by {e.user}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/project/project-files.tsx
+++ b/src/components/project/project-files.tsx
@@ -1,0 +1,62 @@
+"use client";
+import { useEffect, useState } from 'react';
+import { useAuth } from '@/contexts/auth-provider';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+export default function ProjectFiles({ projectId }: { projectId: string }) {
+  const [files, setFiles] = useState<string[]>([]);
+  const [name, setName] = useState('');
+  const [content, setContent] = useState('');
+  const { user } = useAuth();
+
+  const load = async () => {
+    const res = await fetch(`/api/projects/${projectId}/files`);
+    const data = await res.json();
+    setFiles(data.files);
+  };
+
+  useEffect(() => { load(); }, [projectId]);
+
+  const addFile = async () => {
+    await fetch(`/api/projects/${projectId}/files`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, content })
+    });
+    await fetch(`/api/projects/${projectId}/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'add', file: name, user: user?.uid || 'anon' })
+    });
+    setName('');
+    setContent('');
+    load();
+  };
+
+  const viewFile = async (file: string) => {
+    await fetch(`/api/projects/${projectId}/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'view', file, user: user?.uid || 'anon' })
+    });
+    const res = await fetch(`/api/projects/${projectId}/files/${file}`);
+    const text = await res.text();
+    alert(text);
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex gap-2">
+        <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="File name" />
+        <Input value={content} onChange={(e) => setContent(e.target.value)} placeholder="Content" />
+        <Button onClick={addFile}>Upload</Button>
+      </div>
+      <ul className="list-disc pl-4">
+        {files.map(f => (
+          <li key={f} className="cursor-pointer underline text-blue-600" onClick={() => viewFile(f)}>{f}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/project/project-list.tsx
+++ b/src/components/project/project-list.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import AddProjectForm from './add-project-form';
+
+interface Project { id: string; name: string; }
+
+export default function ProjectList() {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const load = async () => {
+    const res = await fetch('/api/projects');
+    const data = await res.json();
+    setProjects(data.projects);
+  };
+  useEffect(() => { load(); }, []);
+  return (
+    <div className="space-y-4">
+      <AddProjectForm onCreated={load} />
+      <ul className="list-disc pl-4">
+        {projects.map((p) => (
+          <li key={p.id}>
+            <Link className="text-blue-600 underline" href={`/projects/${p.id}`}>{p.name}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/lib/data/storage.ts
+++ b/src/lib/data/storage.ts
@@ -1,0 +1,35 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+const dataDir = path.join(process.cwd(), 'data');
+
+export async function ensureDir(dirPath: string) {
+  await fs.mkdir(dirPath, { recursive: true });
+}
+
+export async function readJSON<T>(filePath: string, defaultData: T): Promise<T> {
+  try {
+    const data = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(data) as T;
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      return defaultData;
+    }
+    throw err;
+  }
+}
+
+export async function writeJSON(filePath: string, data: any): Promise<void> {
+  await ensureDir(path.dirname(filePath));
+  await fs.writeFile(filePath, JSON.stringify(data, null, 2));
+}
+
+export async function appendJSONLine(filePath: string, data: any): Promise<void> {
+  await ensureDir(path.dirname(filePath));
+  const line = JSON.stringify(data) + '\n';
+  await fs.appendFile(filePath, line);
+}
+
+export function getDataDir() {
+  return dataDir;
+}


### PR DESCRIPTION
## Summary
- add simple project CRUD API endpoints
- add file management and event logging APIs
- implement project list and project pages
- log file view/upload events
- link to projects from homepage
- include storage helpers and placeholder data folder

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npm run typecheck` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_684364a614c883298f773ada5e529d06